### PR TITLE
Include active_support before active_support/core_ext in scraper.rb

### DIFF
--- a/lib/securities/scraper.rb
+++ b/lib/securities/scraper.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 require 'uri'
 require 'net/http'


### PR DESCRIPTION
As per the advice from the rails dev at https://github.com/rails/rails/issues/14664 I have included `require 'active_support'` before the line `require 'active_support/core_ext'`. This fixes my error in trying to use the indicators gem which currently requires the securities gem.

Before this change I was getting the error:

```
/home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/number_helper.rb:1:in `<top (required)>'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext/numeric/conversions.rb:2:in `require'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext/numeric.rb:3:in `require'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext/numeric.rb:3:in `<top (required)>'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext.rb:2:in `require'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext.rb:1:in `each'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.1/lib/active_support/core_ext.rb:1:in `<top (required)>'
        from /home/david/.rvm/gems/ruby-2.2.1/gems/securities-2.0.1/lib/securities/scraper.rb:1:in `require'
```
